### PR TITLE
Correct typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-languages: ruby
+language: ruby
 rvm:
 - 2.3
 - jruby


### PR DESCRIPTION
[Linting](https://api.travis-ci.org/lint) revealed a typo